### PR TITLE
fix: bump version

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,5 +1,5 @@
 APP = {
     "name": "CLI TikTok",
     "proxitok_instance": "https://proxitok.pabloferreiro.es",
-    "version": 0.75
+    "version": 0.80
 }


### PR DESCRIPTION
Presumed intention, using [v0.8 release](https://github.com/nanometer5088/CLI-TikTok/releases/tag/v0.8) as a reference.